### PR TITLE
Fix FAQ expansion direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@ section{position:relative}
   box-shadow:0 10px 28px rgba(0,0,0,.35), inset 0 0 0 1px #ffffff06;
   display:grid; grid-template-columns:auto 1fr; gap:14px; align-items:flex-start;
 }
+details.card{display:block}
 .badge{
   width:42px;height:42px;border-radius:12px;
   display:grid;place-items:center;font-size:20px;font-weight:900;


### PR DESCRIPTION
## Summary
- Ensure FAQ answers expand downward by overriding card layout for <details>

## Testing
- `node -v`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689601f3e1b0833191f8a3f070aa253a