### PR TITLE
Add basic mobile responsive styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 }
 
 *{box-sizing:border-box}
+img,picture,video,canvas,svg{max-width:100%;height:auto}
 html,body{height:100%}
 html,body{overflow-x:hidden} /* footer wave güvenliği */
 body{
@@ -54,6 +55,11 @@ section{position:relative}
 }
 .nav-cta:hover{transform:translateY(-1px); box-shadow:inset 0 0 0 1px #ffffff10, 0 10px 28px rgba(255,127,80,.25)}
 .nav-cta .dot{width:7px;height:7px;border-radius:999px;background:var(--ok);box-shadow:0 0 12px var(--ok)}
+
+@media (max-width:600px){
+  .nav-inner{flex-direction:column;gap:8px}
+  .nav-cta{width:100%;justify-content:center}
+}
 
 /* -------- Hero -------- */
 .hero{


### PR DESCRIPTION
## Summary
- make images and media scale fluidly on smaller screens
- adjust header layout for narrow viewports with a simple mobile media query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896070aead08331bcd0b0d3934ae902