### PR TITLE
Fix TOC overlap on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,18 @@ nav[aria-label="İçindekiler"]::-webkit-scrollbar-thumb:hover {
   background-color: #ff9966;
 }
 
+@media (max-width: 768px) {
+  #makale > div {
+    grid-template-columns: 1fr !important;
+  }
+  #makale nav[aria-label="İçindekiler"] {
+    position: static !important;
+    height: auto !important;
+    overflow: visible !important;
+    margin-bottom: 2rem;
+  }
+}
+
 </style>
 <script type="application/ld+json">
 [


### PR DESCRIPTION
## Summary
- Ensure mobile layouts stack the table of contents above the article
- Disable sticky/100vh behavior for the TOC on small screens to prevent content overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960997017083319eac2cd8f9f85bf4